### PR TITLE
fancy booleans (checkboxes, radio buttons, and bootstrap switches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,26 @@ end
 
 # VERSION HISTORY
 
+#### TBR - v0.5.19
+Given a table generated with this schema:
+rails generate model Thing abc:boolean dfg:boolean hij:boolean klm_at:datetime
+
+• Use new flag `--display-as` to determine how the booleans will be displayed: checkbox, radio, or switch
+
+rails generate hot_glue:scaffold Thing --include=abc,dfg,hij,klm_at --god --modify='klm_at{yes|no}' --display-as='abc{checkbox},dfg{radio},hij{switch}'
+
+starting with this version, you must specify a default in config/hot_glue.yml
+
+:default_boolean_display: 'radio'
+• The options are checkbox, radio, or switch. please note that before this upgrade to booleans, all booleans displayed as what is now called 'radio'
+
+![Screenshot 2023-08-22 at 7 40 44 PM](https://github.com/hot-glue-for-rails/hot-glue/assets/59002/ba076cb0-fa40-4b68-a1a0-cab496670e00)
+
+
+You still use the --modify flag to determine the truthy and falsy values, which are also used as the labels on the editable screen if you have selected radio
+
+
+
 #### 2023-09-01 - v0.5.18
 - there three ways Hot Glue deals with Datetime fields:
 - 

--- a/config/hot_glue.yml
+++ b/config/hot_glue.yml
@@ -1,5 +1,5 @@
 ---
 :layout: hotglue
 :markup: erb
-
+:default_boolean_display: radio
 :sample_file_path: spec/files/computer_code.jpg

--- a/dummy/config/hot_glue.yml
+++ b/dummy/config/hot_glue.yml
@@ -1,5 +1,6 @@
 ---
 :layout: bootstrap
 :markup: erb
+:default_boolean_display: radio
 
 :sample_file_path: spec/files/computer_code.jpg

--- a/lib/generators/hot_glue/field_factory.rb
+++ b/lib/generators/hot_glue/field_factory.rb
@@ -44,7 +44,6 @@ class FieldFactory
               AttachmentField
             end
     @class_name = class_name
-
     @field = field_class.new(name: name,
                              layout_strategy: generator.layout_strategy,
                              form_placeholder_labels: generator.form_placeholder_labels,
@@ -58,6 +57,8 @@ class FieldFactory
                              update_show_only: generator.update_show_only,
                              attachment_data: generator.attachments[name.to_sym],
                              sample_file_path: generator.sample_file_path,
-                             modify: generator.modify[name.to_sym] || nil )
+                             modify: generator.modify[name.to_sym] || nil,
+                             display_as: generator.display_as[name.to_sym] || nil,
+                             default_boolean_display: generator.default_boolean_display)
   end
 end

--- a/lib/generators/hot_glue/field_factory.rb
+++ b/lib/generators/hot_glue/field_factory.rb
@@ -44,6 +44,7 @@ class FieldFactory
               AttachmentField
             end
     @class_name = class_name
+
     @field = field_class.new(name: name,
                              layout_strategy: generator.layout_strategy,
                              form_placeholder_labels: generator.form_placeholder_labels,

--- a/lib/generators/hot_glue/fields/association_field.rb
+++ b/lib/generators/hot_glue/fields/association_field.rb
@@ -5,7 +5,9 @@ class AssociationField < Field
 
   attr_accessor :assoc_name, :assoc_class, :assoc
 
-  def initialize(name: , class_name: , alt_lookups: , singular: , update_show_only: ,
+  def initialize(alt_lookups: , class_name: , default_boolean_display:, display_as: ,
+                 name: , singular: ,
+                 update_show_only: ,
                  hawk_keys: , auth: , sample_file_path:,  ownership_field: ,
                  attachment_data: nil , layout_strategy: , form_placeholder_labels: nil,
                  form_labels_position:, modify:  )

--- a/lib/generators/hot_glue/fields/attachment_field.rb
+++ b/lib/generators/hot_glue/fields/attachment_field.rb
@@ -1,6 +1,8 @@
 class AttachmentField < Field
   attr_accessor :attachment_data
-  def initialize(name:, class_name:, alt_lookups:, singular:, update_show_only:, hawk_keys:, auth:,
+  def initialize(name:, class_name:, alt_lookups:, default_boolean_display: ,
+                 display_as:,
+                 singular:, update_show_only:, hawk_keys:, auth:,
                  sample_file_path: nil, attachment_data:, ownership_field:, layout_strategy: ,
                  form_placeholder_labels: , form_labels_position:, modify: )
     super

--- a/lib/generators/hot_glue/fields/boolean_field.rb
+++ b/lib/generators/hot_glue/fields/boolean_field.rb
@@ -1,3 +1,4 @@
+
 class BooleanField < Field
   def spec_setup_and_change_act(which_partial = nil)
     "      new_#{name} = 1 \n" +
@@ -15,15 +16,40 @@ class BooleanField < Field
   def spec_list_view_assertion
     ["expect(page).to have_content(#{singular}#{1}.#{name} ? 'YES' : 'NO')"].join("\n      ")
   end
-  
-  
+
+  def label_for
+    "#{singular}_#{name}"
+  end
+
+  def radio_button_display
+    "  <%= f.radio_button(:#{name}, '0', checked: #{singular}.#{name}  ? '' : 'checked', class: '#{@layout_strategy.form_checkbox_input_class}') %>\n" +
+      "  <%= f.label(:#{name}, value: '#{modify_binary? && modify[:binary][:falsy] || 'No'}', for: '#{singular}_#{name}_0') %>\n" +
+      " <br /> <%= f.radio_button(:#{name}, '1',  checked: #{singular}.#{name}  ? 'checked' : '' , class: '#{@layout_strategy.form_checkbox_input_class}') %>\n" +
+      "  <%= f.label(:#{name}, value: '#{modify_binary? && modify[:binary][:truthy] || 'Yes'}', for: '#{singular}_#{name}_1') %>\n"
+  end
+
+  def checkbox_display
+    "<%= f.check_box(:#{name}, class: '#{@layout_strategy.form_checkbox_input_class}', id: '#{singular}_#{name}') %>\n"
+  end
+
+  def switch_display
+    "<%= f.check_box(:#{name}, class: '#{@layout_strategy.form_checkbox_input_class}',  id: '#{singular}_#{name}', role: 'switch') %>\n"
+  end
+
+  def form_field_display
+    "<div class='#{@layout_strategy.form_checkbox_wrapper_class} #{'form-switch' if display_boolean_as == 'switch'}'>\n" +
+      (if display_boolean_as == 'radio'
+      radio_button_display
+    elsif display_boolean_as == 'checkbox'
+      checkbox_display
+    elsif display_boolean_as == 'switch'
+      switch_display
+   end) + "</div> \n"
+  end
+
   def form_field_output
     (form_labels_position == 'before' ?  " <br />"  : "") +
-      "  <%= f.radio_button(:#{name},  '0', checked: #{singular}.#{name}  ? '' : 'checked') %>\n" +
-      "  <%= f.label(:#{name}, value: '#{modify_binary? && modify[:binary][:falsy] || 'No'}', for: '#{singular}_#{name}_0') %>\n" +
-      " <br /> <%= f.radio_button(:#{name}, '1',  checked: #{singular}.#{name}  ? 'checked' : '') %>\n" +
-      "  <%= f.label(:#{name}, value: '#{modify_binary? && modify[:binary][:truthy] || 'Yes'}', for: '#{singular}_#{name}_1') %>\n" +
-      (form_labels_position == 'after' ?  " <br />"  : "")
+      form_field_display + (form_labels_position == 'after' ?  " <br />"  : "")
   end
 
   def line_field_output
@@ -44,5 +70,9 @@ class BooleanField < Field
       NO
     <% end %>"
     end
+  end
+
+  def label_class
+    super + " form-check-label"
   end
 end

--- a/lib/generators/hot_glue/fields/boolean_field.rb
+++ b/lib/generators/hot_glue/fields/boolean_field.rb
@@ -29,11 +29,11 @@ class BooleanField < Field
   end
 
   def checkbox_display
-    "<%= f.check_box(:#{name}, class: '#{@layout_strategy.form_checkbox_input_class}', id: '#{singular}_#{name}') %>\n"
+    "<%= f.check_box(:#{name}, class: '#{@layout_strategy.form_checkbox_input_class}', id: '#{singular}_#{name}', checked: #{singular}.#{name}) %>\n"
   end
 
   def switch_display
-    "<%= f.check_box(:#{name}, class: '#{@layout_strategy.form_checkbox_input_class}',  id: '#{singular}_#{name}', role: 'switch') %>\n"
+    "<%= f.check_box(:#{name}, class: '#{@layout_strategy.form_checkbox_input_class}', role: 'switch', id: '#{singular}_#{name}', checked: #{singular}.#{name}) %>\n"
   end
 
   def form_field_display

--- a/lib/generators/hot_glue/fields/field.rb
+++ b/lib/generators/hot_glue/fields/field.rb
@@ -148,7 +148,7 @@ class Field
   end
 
   def label_class
-    "text-muted small"
+    "text-muted small form-text"
   end
 
   def label_for

--- a/lib/generators/hot_glue/fields/field.rb
+++ b/lib/generators/hot_glue/fields/field.rb
@@ -1,6 +1,6 @@
 class Field
   attr_accessor :assoc_model, :assoc_name, :assoc_class, :associations, :alt_lookups, :auth,
-                :assoc_label,  :class_name,  :form_placeholder_labels, :form_labels_position,
+                :assoc_label,  :class_name, :default_boolean_display, :display_as, :form_placeholder_labels, :form_labels_position,
                 :hawk_keys,   :layout_strategy, :limit, :modify, :name, :object, :sample_file_path,
                 :singular_class,  :singular, :sql_type, :ownership_field,
                 :update_show_only
@@ -10,6 +10,8 @@ class Field
     alt_lookups: ,
     attachment_data: nil,
     class_name: ,
+    default_boolean_display: ,
+    display_as: ,
     form_labels_position:,
     form_placeholder_labels: ,
     hawk_keys: nil,
@@ -34,6 +36,9 @@ class Field
     @ownership_field = ownership_field
     @form_labels_position = form_labels_position
     @modify = modify
+    @display_as = display_as
+
+    @default_boolean_display = default_boolean_display
 
     # TODO: remove knowledge of subclasses from Field
     unless self.class == AttachmentField
@@ -131,5 +136,22 @@ class Field
 
   def modify_binary? # safe
     !!(modify && modify[:binary])
+  end
+
+  def display_boolean_as
+
+    if ! default_boolean_display
+      raise "Starting with 0.5.18 you must set default_boolean_display in config/hot_glue.yml to 'radio', 'checkbox', or 'switch'. For parity with legacy behavior, use radio."
+    end
+
+    display_as && display_as[:boolean] || default_boolean_display
+  end
+
+  def label_class
+    "text-muted small"
+  end
+
+  def label_for
+
   end
 end

--- a/lib/generators/hot_glue/layout/builder.rb
+++ b/lib/generators/hot_glue/layout/builder.rb
@@ -3,6 +3,7 @@
 module HotGlue
   module Layout
     class Builder
+      include DefaultConfigLoader
       attr_reader :include_setting,
                   :downnest_object,
                   :buttons_width, :columns,
@@ -30,7 +31,8 @@ module HotGlue
         @specified_grouping_mode = include_setting.include?(":")
         @bootstrap_column_width = generator.bootstrap_column_width
         @big_edit = generator.big_edit
-        @default_boolean_display = generator.get_default_from_config(key: :default_boolean_display)
+
+        @default_boolean_display = get_default_from_config(key: :default_boolean_display)
 
       end
 
@@ -45,7 +47,7 @@ module HotGlue
           },
           buttons: { size: @buttons_width},
           modify: @modify,
-          display: @display_as
+          display_as: @display_as
         }
 
         # downnest_object.each do |child, size|

--- a/lib/generators/hot_glue/layout/builder.rb
+++ b/lib/generators/hot_glue/layout/builder.rb
@@ -17,6 +17,7 @@ module HotGlue
         @generator = generator
 
         @modify = generator.modify
+        @display_as =  generator.display_as
         @columns = generator.columns
         @smart_layout = generator.smart_layout
         @stacked_downnesting = generator.stacked_downnesting || false
@@ -29,6 +30,8 @@ module HotGlue
         @specified_grouping_mode = include_setting.include?(":")
         @bootstrap_column_width = generator.bootstrap_column_width
         @big_edit = generator.big_edit
+        @default_boolean_display = generator.get_default_from_config(key: :default_boolean_display)
+
       end
 
       def construct
@@ -41,7 +44,8 @@ module HotGlue
 
           },
           buttons: { size: @buttons_width},
-          modify: @modify
+          modify: @modify,
+          display: @display_as
         }
 
         # downnest_object.each do |child, size|

--- a/lib/generators/hot_glue/layout_strategy/base.rb
+++ b/lib/generators/hot_glue/layout_strategy/base.rb
@@ -32,5 +32,6 @@ module LayoutStrategy
     def style_with_flex_basis(x); "" ; end
     def form_checkbox_input_class; ""; end
     def form_checkbox_label_class; ""; end
+    def form_checkbox_wrapper_class; ""; end
   end
 end

--- a/lib/generators/hot_glue/layout_strategy/base.rb
+++ b/lib/generators/hot_glue/layout_strategy/base.rb
@@ -30,5 +30,7 @@ module LayoutStrategy
     def page_begin; '<div> '; end
     def page_end ; '</div> '; end
     def style_with_flex_basis(x); "" ; end
+    def form_checkbox_input_class; ""; end
+    def form_checkbox_label_class; ""; end
   end
 end

--- a/lib/generators/hot_glue/layout_strategy/bootstrap.rb
+++ b/lib/generators/hot_glue/layout_strategy/bootstrap.rb
@@ -56,4 +56,16 @@ class LayoutStrategy::Bootstrap < LayoutStrategy::Base
   def page_end
     '</div> </div>'
   end
+
+  def form_checkbox_input_class
+    "form-check-input"
+  end
+
+  def form_checkbox_wrapper_class
+    "form-check"
+  end
+
+  def form_checkbox_label_class
+    "form-check-label"
+  end
 end

--- a/lib/generators/hot_glue/markup_templates/erb.rb
+++ b/lib/generators/hot_glue/markup_templates/erb.rb
@@ -87,7 +87,11 @@ module  HotGlue
 
             field_error_name = columns_map[col].field_error_name
 
-            the_label = "\n<label class='small form-text text-muted'>#{col.to_s.humanize}</label>"
+
+            label_class = columns_map[col].label_class
+            label_for = columns_map[col].label_for
+
+            the_label = "\n<label class='#{label_class}' for='#{label_for}'>#{col.to_s.humanize}</label>"
             show_only_open = ""
             show_only_close = ""
 

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -17,7 +17,8 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
 
   source_root File.expand_path('templates', __dir__)
   attr_accessor :alt_lookups, :attachments, :auth, :big_edit, :button_icons, :bootstrap_column_width, :columns,
-                :downnest_children, :downnest_object, :hawk_keys, :layout_object, :modify,
+                :default_boolean_display,
+                :display_as, :downnest_children, :downnest_object, :hawk_keys, :layout_object, :modify,
                 :nest_with, :path, :plural, :sample_file_path, :show_only_data, :singular,
                 :singular_class, :smart_layout, :stacked_downnesting, :update_show_only, :ownership_field,
                 :layout_strategy, :form_placeholder_labels, :form_labels_position
@@ -79,6 +80,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
   class_option :bootstrap_column_width, default: nil # must be nil to detect if user has not passed
   class_option :button_icons, default: nil
   class_option :modify, default: {}
+  class_option :display_as, default: {}
 
   def initialize(*meta_args)
     super
@@ -118,6 +120,9 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
     @bootstrap_column_width ||= options['bootstrap_column_width'] ||
       get_default_from_config(key: :bootstrap_column_width) || 2
 
+
+
+    @default_boolean_display = get_default_from_config(key: :default_boolean_display)
     if options['layout']
       layout = options['layout']
     else
@@ -209,6 +214,19 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
         end
       end
     end
+
+    @display_as = {}
+    if !options['display_as'].empty?
+      display_input = options['display_as'].split(",")
+
+      display_input.each do |setting|
+        setting =~ /(.*){(.*)}/
+        key, lookup_as = $1, $2
+        @display_as[key.to_sym] =  {boolean: $2}
+      end
+    end
+
+
     @update_show_only = []
     if !options['update_show_only'].empty?
       @update_show_only += options['update_show_only'].split(",").collect(&:to_sym)

--- a/spec/dummy/config/hot_glue.yml
+++ b/spec/dummy/config/hot_glue.yml
@@ -1,3 +1,4 @@
 ---
 :layout: hotglue
 :markup: erb
+:default_boolean_display: radio

--- a/spec/lib/generators/hot_glue/layout/builder_spec.rb
+++ b/spec/lib/generators/hot_glue/layout/builder_spec.rb
@@ -76,7 +76,8 @@ describe HotGlue::Layout::Builder do
         generator =  OpenStruct.new(downnest_object: {get_emails_rules: 4} ,
                                     columns: [:api_key, :api_id],
                                     smart_layout: false,
-                                    bootstrap_column_width: 2  )
+                                    bootstrap_column_width: 2,
+                                    get_default_from_config: OpenStruct.new('radio'))
 
         builder = HotGlue::Layout::Builder.new(include_setting: "api_key,api_id:",
                                                generator: generator,

--- a/spec/lib/generators/hot_glue/layout/builder_spec.rb
+++ b/spec/lib/generators/hot_glue/layout/builder_spec.rb
@@ -2,15 +2,18 @@ require 'rails_helper'
 
 
 describe HotGlue::Layout::Builder do
-  describe "#initialize" do
-    let(:builder) {HotGlue::Layout::Builder.new(include_setting: nil,
-                                                 downnest_object: {},
-                                                 no_edit: false,
-                                                 no_delete: false,
-                                                 columns: [],
-                                                 smart_layout: true)
-    }
-  end
+
+
+
+  # describe "#initialize" do
+  #   let(:builder) {HotGlue::Layout::Builder.new(include_setting: nil,
+  #                                                downnest_object: {},
+  #                                                no_edit: false,
+  #                                                no_delete: false,
+  #                                                columns: [],
+  #                                                smart_layout: true)
+  #   }
+  # end
 
   describe "#construct" do
     describe "without smart layouts" do
@@ -44,6 +47,7 @@ describe HotGlue::Layout::Builder do
                                               [:time_of_day, :selected, :genre]]
                                            },
                                 portals: {},
+                                display_as: nil,
                                 buttons: {:size=>2},
                                 modify: nil })
 
@@ -76,9 +80,9 @@ describe HotGlue::Layout::Builder do
         generator =  OpenStruct.new(downnest_object: {get_emails_rules: 4} ,
                                     columns: [:api_key, :api_id],
                                     smart_layout: false,
-                                    bootstrap_column_width: 2,
-                                    get_default_from_config: OpenStruct.new('radio'))
+                                    bootstrap_column_width: 2)
 
+        #
         builder = HotGlue::Layout::Builder.new(include_setting: "api_key,api_id:",
                                                generator: generator,
                                                buttons_width: 2)
@@ -88,6 +92,7 @@ describe HotGlue::Layout::Builder do
         expect(result[:portals][:get_emails_rules][:size]).to eq(4)
       end
     end
+
 
     describe "with smart layouts" do
       describe "when not using semicolons" do
@@ -113,7 +118,6 @@ describe HotGlue::Layout::Builder do
                                       buttons_width: 0,
                                       bootstrap_column_width: 2,
                                       include_setting: "api_key,api_id:")
-
           builder = HotGlue::Layout::Builder.new(include_setting: '',
                                                  generator: generator,
                                                  buttons_width: 0)

--- a/spec/lib/generators/hot_glue/scaffold_generator_spec.rb
+++ b/spec/lib/generators/hot_glue/scaffold_generator_spec.rb
@@ -614,15 +614,43 @@ describe HotGlue::ScaffoldGenerator do
       expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '') %>")
       expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '' , class: '')")
       expect(res).to include("<%= f.label(:selected, value: 'on', for: 'jkl_selected_1') %>")
-
-
-
-
-      # res = File.read("spec/dummy/app/views/jkls/_line.erb")
-      # byebug
-      # expect(res).to include("<%= jkl.selected ? 'on' : 'off' %>")
     end
   end
+
+  describe "--display" do
+    it "should let me specify a boolean as a radio" do
+      response = Rails::Generators.invoke("hot_glue:scaffold",
+                                          ["Jkl", "--gd",  "--include=selected", "--display-as=selected{radio}", "--modify=selected{on|off}"])
+
+      res = File.read("spec/dummy/app/views/jkls/_form.erb")
+      expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '')")
+      expect(res).to include("<%= f.label(:selected, value: 'off', for: 'jkl_selected_0') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '' , class: '')")
+      expect(res).to include("<%= f.label(:selected, value: 'on', for: 'jkl_selected_1') %>")
+
+    end
+
+    it "should let me specify a boolean as a checkbox" do
+      response = Rails::Generators.invoke("hot_glue:scaffold",
+                                          ["Jkl", "--gd",  "--include=selected", "--display-as=selected{checkbox}"])
+
+      res = File.read("spec/dummy/app/views/jkls/_form.erb")
+
+      expect(res).to include("<%= f.check_box(:selected, class: '', id: 'jkl_selected', checked: jkl.selected) %>")
+    end
+
+    it "should let me specify a booleans as a switch" do
+      response = Rails::Generators.invoke("hot_glue:scaffold",
+                                          ["Jkl", "--gd",  "--include=selected", "--display-as=selected{switch}" ])
+
+      res = File.read("spec/dummy/app/views/jkls/_form.erb")
+      expect(res).to include("<%= f.check_box(:selected, class: '', role: 'switch', id: 'jkl_selected', checked: jkl.selected) %>")
+
+    end
+  end
+
+
 
   describe "ujs syntax" do
     it "should make detele with 'confirm': true for ujs_syntax=true" do

--- a/spec/lib/generators/hot_glue/scaffold_generator_spec.rb
+++ b/spec/lib/generators/hot_glue/scaffold_generator_spec.rb
@@ -608,10 +608,11 @@ describe HotGlue::ScaffoldGenerator do
 
       res = File.read("spec/dummy/app/views/jkls/_form.erb")
 
-      expect(res).to include("<%= f.radio_button(:selected,  '0', checked: jkl.selected  ? '' : 'checked') %>")
+
+      expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '')")
       expect(res).to include("<%= f.label(:selected, value: 'off', for: 'jkl_selected_0') %>")
-      expect(res).to include("<%= f.radio_button(:selected,  '0', checked: jkl.selected  ? '' : 'checked') %>")
-      expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '' , class: '')")
       expect(res).to include("<%= f.label(:selected, value: 'on', for: 'jkl_selected_1') %>")
 
 
@@ -697,7 +698,7 @@ describe HotGlue::ScaffoldGenerator do
 
       res = File.read("spec/dummy/app/views/abcs/_form.erb")
 
-      label_pos = res.index /<label class='small form-text text-muted'>Name\<\/label>/
+      label_pos = res.index /<label class='text-muted small form-text' for=''>Name\<\/label>/
       field_pos = res.index /<%= f.text_field :name, value: abc.name, autocomplete: 'off', size: 40, class: 'form-control', type: '' %>/
       expect(label_pos < field_pos).to be(true)
     end

--- a/spec/lib/hot_glue/field_factory_spec.rb
+++ b/spec/lib/hot_glue/field_factory_spec.rb
@@ -6,6 +6,8 @@ describe FieldFactory do
                           name: "how_many",
                           generator: OpenStruct.new({
                                                   modify: {},
+                                                  display_as: {},
+                                                  default_boolean_display: 'radio',
                                                   form_labels_position: nil,
                                                   singular_class: "Hgi",
                                                   layout_strategy: nil,

--- a/spec/lib/hot_glue/markup_templates/erb_spec.rb
+++ b/spec/lib/hot_glue/markup_templates/erb_spec.rb
@@ -16,7 +16,7 @@ describe HotGlue::ErbTemplate do
   # t.timestamps
 
   let(:layout_strategy) {
-    LayoutStrategy::HotGlue.new(OpenStruct.new({}))
+    LayoutStrategy::HotGlue.new(OpenStruct.new)
   }
 
   def base_generator options
@@ -26,9 +26,11 @@ describe HotGlue::ErbTemplate do
                     attachments: {},
                     bootstrap_column_width: 2,
                     singular_class: "Jkl",
+                    layout_strategy: layout_strategy,
                     form_placeholder_labels: nil,
                     modify: {},
-                    get_default_from_config: OpenStruct.new({default_boolean_display:  'radio'}),
+                    display_as: {},
+                    default_boolean_display: "radio",
                     singular: "jkl" }.merge(  hawk_keys: options[:hawk_keys],
                                           columns: options[:columns],
                                           form_placeholder_labels: options[:form_placeholder_labels],
@@ -54,6 +56,7 @@ describe HotGlue::ErbTemplate do
       magic_buttons: [],
       small_buttons: false,
       inline_list_labels: 'omit',
+      layout_strategy: layout_strategy,
       form_placeholder_labels: options[:form_placeholder_labels],
       form_labels_position: options[:form_labels_position],
       update_show_only: [],
@@ -76,7 +79,9 @@ describe HotGlue::ErbTemplate do
 
       selected: FieldFactory.new(type: :boolean, name: "selected", generator: generator).field,
       name: FieldFactory.new(type: :string, name: "name", generator: generator).field,
-      hgi_id: AssociationField.new(layout_strategy: layout_strategy,
+      hgi_id: AssociationField.new(
+              default_boolean_display: "radio" , display_as: {},
+              layout_strategy: layout_strategy,
                                    form_labels_position: 'before',
                                    ownership_field: "", name: "hgi_id", class_name: "Jkl", alt_lookups: {},
                                    singular: "Jkl", update_show_only: nil, hawk_keys: options[:hawk_keys],
@@ -165,10 +170,10 @@ describe HotGlue::ErbTemplate do
       expect(res).to include("<%= time_field_localized(f, :time_of_day, jkl.time_of_day,  'Time of day', nil) %>")
     end
 
-    it "should make a boolean column " do
+    it "should make a boolean column" do
       res = factory_all_form_fields({columns: [:selected]})
-      expect(res).to include("<%= f.radio_button(:selected,  '0', checked: jkl.selected  ? '' : 'checked') %>")
-      expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '' , class: '') %>")
     end
 
 
@@ -185,8 +190,7 @@ describe HotGlue::ErbTemplate do
     it "with 'before' should make the labels appear before the field" do
       res = factory_all_form_fields({columns: [:name, :blurb],
                                      form_labels_position: 'before'})
-
-      label_pos = res.index /<label class='small form-text text-muted'>Name/
+      label_pos = res.index /<label class='text-muted small form-text' for=''>Name/
       field_pos = res.index /<%= f.text_field :name,/
       expect(label_pos < field_pos).to be(true)
     end
@@ -195,7 +199,7 @@ describe HotGlue::ErbTemplate do
       res = factory_all_form_fields({columns: [:name, :blurb],
                                          form_labels_position: 'after'}
       )
-      label_pos = res.index /<label class='small form-text text-muted'>Name/
+      label_pos = res.index /<label class='text-muted small form-text' for=''>Name/
       field_pos = res.index /<%= f.text_field :name,/
       expect(label_pos > field_pos).to be(true)
     end
@@ -293,6 +297,10 @@ describe HotGlue::ErbTemplate do
       expect(res).to_not include("<label class='small form-text text-muted'>Blurb</label>")
       expect(res).to_not include("<label class='small form-text text-muted'>Name</label>")
     end
+  end
+
+  describe "boolean display" do
+
   end
 
   describe "with show only fields" do

--- a/spec/lib/hot_glue/markup_templates/erb_spec.rb
+++ b/spec/lib/hot_glue/markup_templates/erb_spec.rb
@@ -28,6 +28,7 @@ describe HotGlue::ErbTemplate do
                     singular_class: "Jkl",
                     form_placeholder_labels: nil,
                     modify: {},
+                    get_default_from_config: OpenStruct.new({default_boolean_display:  'radio'}),
                     singular: "jkl" }.merge(  hawk_keys: options[:hawk_keys],
                                           columns: options[:columns],
                                           form_placeholder_labels: options[:form_placeholder_labels],

--- a/spec/lib/hot_glue/markup_templates/erb_spec.rb
+++ b/spec/lib/hot_glue/markup_templates/erb_spec.rb
@@ -29,7 +29,7 @@ describe HotGlue::ErbTemplate do
                     layout_strategy: layout_strategy,
                     form_placeholder_labels: nil,
                     modify: {},
-                    display_as: {},
+                    display_as: options[:display_as] || {},
                     default_boolean_display: "radio",
                     singular: "jkl" }.merge(  hawk_keys: options[:hawk_keys],
                                           columns: options[:columns],
@@ -40,14 +40,13 @@ describe HotGlue::ErbTemplate do
 
   def factory_all_form_fields(options)
     generator = base_generator(options)
-
     builder = HotGlue::Layout::Builder.new(include_setting: '',
                                            generator: generator,
                                            buttons_width: 0,)
     layout_object = builder.construct
 
     @template_builder = HotGlue::ErbTemplate.new(
-      show_only: [],
+      show_only: options[:show_only] || [],
       singular_class: options[:singular_class] || "Jkl",
       singular: options[:singular] || "jkl",
       hawk_keys: options[:hawk_keys] || {},
@@ -300,23 +299,48 @@ describe HotGlue::ErbTemplate do
   end
 
   describe "boolean display" do
+    it "should render checkboxes" do
+      res = factory_all_form_fields({columns: [:selected],
+                                     display_as: {selected: {boolean: 'checkbox'}},
+                                     no_list_heading: true,
+                                     inline_list_labels: 'omit'})
 
+      expect(res).to include("<%= f.check_box(:selected, class: '', id: 'jkl_selected', checked: jkl.selected) %>")
+    end
+
+    it "should render radio buttons" do
+      res = factory_all_form_fields({columns: [:selected],
+                                     display_as: {selected: {boolean: 'radio'}},
+                                     no_list_heading: true,
+                                     inline_list_labels: 'omit'})
+
+      expect(res).to include("<%= f.radio_button(:selected, '0', checked: jkl.selected  ? '' : 'checked', class: '') %>")
+      expect(res).to include("<%= f.radio_button(:selected, '1',  checked: jkl.selected  ? 'checked' : '' , class: '') %>")
+
+    end
+
+
+    it "should render switches buttons" do
+      res = factory_all_form_fields({columns: [:selected],
+                                     display_as: {selected: {boolean: 'switch'}},
+                                     no_list_heading: true,
+                                     inline_list_labels: 'omit'})
+
+      expect(res).to include("<%= f.check_box(:selected, class: '', role: 'switch', id: 'jkl_selected', checked: jkl.selected) %>")
+    end
   end
 
   describe "with show only fields" do
+    it "should render the show only fields as viewable on the form" do
+      res = factory_all_form_fields({columns: [:long_description],
+                                     show_only: [:long_description],
+                                     no_list_heading: true,
+                                     inline_list_labels: 'omit'})
 
+      expect(res).to include("<%= jkl.long_description %>")
+    end
   end
 
-  describe "with singular_class" do
-
-  end
-
-  describe "with a col_identifier" do
-
-  end
-
-  describe "with an ownership_field" do
-  end
 
   let (:hawk_keys_for_hgi_id) {{hgi_id: {bind_to: ["current_user.hgis"], optional: false }}}
 


### PR DESCRIPTION
Given a table generated with this schema:
`rails generate model Thing abc:boolean dfg:boolean hij:boolean klm_at:datetime`

• Use new flag `--display-as` to determine how booleans display

`rails generate hot_glue:scaffold Thing --include=abc,dfg,hij,klm_at --god --modify='klm_at{yes|no}' --display-as='abc{checkbox},dfg{radio},hij{switch}'`

starting with this version, you must specify a default in `config/hot_glue.yml`

```
:default_boolean_display: 'radio'
```

• The options are `checkbox`, `radio`, or `switch`. please note that before this upgrade to booleans, all booleans displayed as what is now called 'radio'


![Screenshot 2023-08-22 at 7 40 44 PM](https://github.com/hot-glue-for-rails/hot-glue/assets/59002/ba076cb0-fa40-4b68-a1a0-cab496670e00)


You still use the `--modify` flag to determine the truthy and falsy values, which are also used as the labels on the editable screen if you have selected `radio`