### PR TITLE
fixes timezones use system time;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,13 +1159,13 @@ factory = AgentFactory.new(find_or_create_by_email: agent_company_params[:__look
                             params: modified_params)
 ```
 
-Here the new AgentFactory will recieve any variables by keyword argument, and since you're specifying the calling code here, Hot Glue does not dictate your factory's setup.
+Here the new AgentFactory will receive any variables by keyword argument, and since you're specifying the calling code here, Hot Glue does not dictate your factory's setup.
 However, two special variables are in scope which you can use in your calling code.
 
 `*_params` (where * is the name of the thing you are building)
-`modified_params` a variable that has been transmogrified for the timezone aware input
+`modified_params`
 
-Either one must be recieved by your factory for your factory to create data based off the inputted data. 
+Either one must be received by your factory for your factory to create data based off the inputted data. 
 
 Rememebr, `*_params` has the input params passed only the through the sanitizer, and modified_params has it passed through the timezone aware mechanism and other Hot Glue-specific defaults.
 

--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,15 @@ end
 
 # VERSION HISTORY
 
+
+#### TBR - v0.5.18
+
+- Fixes to timezone handling for datetimes and times. Note that the timezone aware input behavior is only applied to datetimes. Times are passed through to the database as set. 
+- For datetimes, when a user is inputing a datetime,  the timezone is presumed from the Rails config. 
+- (This is the default behavior for Rails.) 
+
+
+
 #### 2023-08-18 - v0.5.17
 
 • Nav templates (`_nav.html.erb`) are now automatically appended to if they exist. Remember nav template live in the views folder at the root of the *namespace*, which is one folder up from whatever folder is being built.

--- a/app/helpers/hot_glue/controller_helper.rb
+++ b/app/helpers/hot_glue/controller_helper.rb
@@ -20,9 +20,10 @@ module HotGlue
     end
 
     def time_field_localized(form_object, field_name, value, label )
+      current_timezone
       form_object.text_field(field_name, class: 'form-control',
                                     type: 'time',
-                                    value: date_to_current_timezone(value, current_timezone)) + timezonize(current_timezone)
+                                    value: value && value.strftime("%H:%M"))
 
     end
 
@@ -32,10 +33,12 @@ module HotGlue
         if current_user.try(:timezone)
           Time.now.in_time_zone(current_user.timezone.to_i).zone
         else
-          Time.zone.name
+          Rails.application.config.time_zone
+          # Time.zone.name
         end
       else
-        Time.zone.name
+        Rails.application.config.time_zone
+        # Time.zone.name
       end
     end
 

--- a/lib/generators/hot_glue/fields/date_field.rb
+++ b/lib/generators/hot_glue/fields/date_field.rb
@@ -10,7 +10,7 @@ class DateField < Field
 
 
   def form_field_output
-    "<%= date_field_localized(f, :#{name}, #{singular}.#{name}, '#{ name.to_s.humanize  }', #{auth ? auth+'.timezone' : 'nil'}) %>"
+    "<%= date_field_localized(f, :#{name}, #{singular}.#{name}, '#{ name.to_s.humanize  }') %>"
   end
 
   def line_field_output

--- a/lib/generators/hot_glue/fields/date_time_field.rb
+++ b/lib/generators/hot_glue/fields/date_time_field.rb
@@ -34,7 +34,7 @@ class DateTimeField < Field
   end
 
   def form_field_output
-    "<%= datetime_field_localized(f, :#{name}, #{singular}.#{name}, '#{ name.to_s.humanize }', #{auth ? auth+'.timezone' : 'nil'}) %>"
+    "<%= datetime_field_localized(f, :#{name}, #{singular}.#{name}, '#{ name.to_s.humanize }') %>"
   end
 
   def line_field_output
@@ -42,7 +42,7 @@ class DateTimeField < Field
       modified_display_output
     else
       "<% unless #{singular}.#{name}.nil? %>
-  <%= #{singular}.#{name}.in_time_zone(current_timezone).strftime('%m/%d/%Y @ %l:%M %p %z') %>
+  <%= #{singular}.#{name}.in_time_zone(current_timezone).strftime('%m/%d/%Y @ %l:%M %p %Z') %>
   <% else %>
   <span class='alert-danger'>MISSING</span>
   <% end %>"

--- a/lib/generators/hot_glue/fields/date_time_field.rb
+++ b/lib/generators/hot_glue/fields/date_time_field.rb
@@ -4,7 +4,7 @@ class DateTimeField < Field
   end
 
   def spec_setup_and_change_act(which_partial = nil)
-    "      " + "new_#{name} = DateTime.current + (rand(100).days) \n" +
+    "      " + "new_#{name} = DateTime.current + 1.year \n" +
     '      ' + "find(\"[name='#{testing_name}[#{ name.to_s }]']\").fill_in(with: new_#{name.to_s})"
 
   end
@@ -18,7 +18,7 @@ class DateTimeField < Field
   end
 
   def spec_setup_let_arg
-    "#{name}: DateTime.current + rand(1000).seconds"
+    "#{name}: DateTime.current + 1.day"
   end
 
   def spec_list_view_assertion

--- a/lib/generators/hot_glue/fields/date_time_field.rb
+++ b/lib/generators/hot_glue/fields/date_time_field.rb
@@ -11,7 +11,7 @@ class DateTimeField < Field
 
   def spec_make_assertion
     if !modify_binary?
-      "expect(page).to have_content(new_#{name}.in_time_zone(current_timezone).strftime('%m/%d/%Y @ %l:%M %p %z').gsub('  ', ' '))"
+      "expect(page).to have_content(new_#{name}.in_time_zone(testing_timezone).strftime('%m/%d/%Y @ %l:%M %p %Z').gsub('  ', ' '))"
     else
       "expect(page).to have_content('#{modify[:binary][:truthy]}'"
     end
@@ -30,7 +30,7 @@ class DateTimeField < Field
   end
 
   def spec_list_view_natural_assertion
-    "expect(page).to have_content(#{singular}#{1}.#{name}.in_time_zone(current_timezone).strftime('%m/%d/%Y @ %l:%M %p %z').gsub('  ', ' '))"
+    "expect(page).to have_content(#{singular}#{1}.#{name}.in_time_zone(testing_timezone).strftime('%m/%d/%Y @ %l:%M %p %Z').gsub('  ', ' '))"
   end
 
   def form_field_output

--- a/lib/generators/hot_glue/fields/time_field.rb
+++ b/lib/generators/hot_glue/fields/time_field.rb
@@ -16,11 +16,17 @@ class TimeField < Field
     <% end %>"
   end
 
+  def spec_setup_and_change_act(which_partial = nil)
+    "      new_#{name} = Time.current + rand(5000).seconds \n"
+  end
+
   def spec_make_assertion
-    "#expect(page).to have_content(new_#{name} .in_time_zone(current_timezone).strftime('%l:%M %p ') + timezonize(current_timezone))"
+    "expect(page).to have_content(new_#{name}.strftime('%l:%M %p'))"
   end
 
   def spec_list_view_assertion
-    "#expect(page).to have_content(#{singular}#{1}.#{name})"
+    # "expect(page).to have_content(#{singular}#{1}.#{name})"
   end
+
+
 end

--- a/lib/generators/hot_glue/fields/time_field.rb
+++ b/lib/generators/hot_glue/fields/time_field.rb
@@ -5,7 +5,7 @@ class TimeField < Field
   end
 
   def form_field_output
-    "<%= time_field_localized(f, :#{name}, #{singular}.#{name},  '#{ name.to_s.humanize  }', #{auth ? auth+'.timezone' : 'nil'}) %>"
+    "<%= time_field_localized(f, :#{name}, #{singular}.#{name},  '#{ name.to_s.humanize  }') %>"
   end
 
   def line_field_output

--- a/lib/generators/hot_glue/fields/time_field.rb
+++ b/lib/generators/hot_glue/fields/time_field.rb
@@ -17,11 +17,13 @@ class TimeField < Field
   end
 
   def spec_setup_and_change_act(which_partial = nil)
-    "      new_#{name} = Time.current + rand(5000).seconds \n"
+    "      new_#{name} = Time.current + 5.seconds \n" +
+    '      ' + "find(\"[name='#{testing_name}[#{ name.to_s }]']\").fill_in(with: new_#{name.to_s})"
+
   end
 
   def spec_make_assertion
-    "expect(page).to have_content(new_#{name}.strftime('%l:%M %p'))"
+    "expect(page).to have_content(new_#{name}.strftime('%l:%M %p').strip)"
   end
 
   def spec_list_view_assertion

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -155,6 +155,8 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
     @controller_build_folder_singular = singular
 
     @auth = options['auth'] || "current_user"
+
+    @god = options['god'] || options['gd'] || false
     @auth_identifier = options['auth_identifier'] || (!@god && @auth.gsub("current_", "")) || nil
 
     if options['nest']
@@ -257,7 +259,6 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
       raise HotGlue::Error, "You passed '#{@inline_list_labels}' as the setting for --inline-list-labels but the only allowed options are before, after, and omit (default)"
     end
 
-    @god = options['god'] || options['gd'] || false
     @specs_only = options['specs_only'] || false
 
     @no_specs = options['no_specs'] || false
@@ -293,7 +294,6 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
     if @god
       @auth = nil
     end
-
     # when in self auth, the object is the same as the authenticated object
 
     if @auth && auth_identifier == @singular
@@ -646,9 +646,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
     end
   end
 
-  def auth_root
-    "authenticate_" + @auth_identifier.split(".")[0] + "!"
-  end
+
 
   def formats
     [format]

--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -5,7 +5,7 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
   helper :hot_glue
   include HotGlue::ControllerHelper
 
-  <% unless @auth_identifier == '' || @god %>before_action :<%= auth_root %><% end %><% if any_nested? %>
+  <% unless @god %>before_action :<%= "authenticate_" + @auth_identifier.split(".")[0] + "!" %><% end %><% if any_nested? %>
     <% nest_chain = [] %> <% @nested_set.each { |arg|
 
     if auth_identifier == arg[:singular]

--- a/lib/generators/hot_glue/templates/system_spec.rb.erb
+++ b/lib/generators/hot_glue/templates/system_spec.rb.erb
@@ -19,8 +19,8 @@ describe 'interaction for <%= controller_class_name %>' do
   before do
     login_as(<%= @auth %>)
   end <% end %> <% if any_datetime_fields? %>
-  let(:current_timezone) {
-    <%= @auth_identifier %>.try(:timezone) || Time.now.strftime("%z").to_i/100
+  let(:testing_timezone) {
+    <% if @auth_identifier %><%= @auth_identifier %>.try(:timezone) || Time.now.zone<% else %> Rails.application.config.time_zone || Time.now.zone<% end %>
   }<% end %>
   describe "index" do
     it "should show me the list" do
@@ -77,7 +77,7 @@ describe 'interaction for <%= controller_class_name %>' do
            eval("#{singular_class}.devise_modules.include?(:confirmable)") && col.to_s == "email"
             "        expect(page).to have_content(#{ singular }1.#{col.to_s})"
       elsif type == :datetime
-            "        expect(page).to have_content(new_#{col.to_s}.in_time_zone(current_timezone).strftime('%m/%d/%Y @ %l:%M %p %z').gsub('  ', ' '))"
+            "        expect(page).to have_content(new_#{col.to_s}.in_time_zone(testing_timezone).strftime('%m/%d/%Y @ %l:%M %p %z').gsub('  ', ' '))"
       else
             "        expect(page).to have_content(new_#{col.to_s})"
       end

--- a/lib/generators/hot_glue/templates/system_spec.rb.erb
+++ b/lib/generators/hot_glue/templates/system_spec.rb.erb
@@ -20,7 +20,7 @@ describe 'interaction for <%= controller_class_name %>' do
     login_as(<%= @auth %>)
   end <% end %> <% if any_datetime_fields? %>
   let(:testing_timezone) {
-    <% if @auth_identifier %><%= @auth_identifier %>.try(:timezone) || Time.now.zone<% else %> Rails.application.config.time_zone || Time.now.zone<% end %>
+    Rails.application.config.time_zone
   }<% end %>
   describe "index" do
     it "should show me the list" do
@@ -59,30 +59,14 @@ describe 'interaction for <%= controller_class_name %>' do
 <%= capybara_make_updates(:update) %>
       click_button "Save"
       within("turbo-frame#<%= @namespace %>__#{dom_id(<%= singular %>1)} ") do
-<%= ((@columns - @attachments.keys.collect(&:to_sym)) - (@show_only+@update_show_only)).map { |col|
-      type = eval("#{singular_class}.columns_hash['#{col}']").type
-
-      if type == :uuid || (type == :integer && col.to_s.ends_with?("_id"))
-        assoc = col.to_s.gsub('_id', '')
-        class_name = eval("#{@singular_class}.reflect_on_association(:#{assoc})").class_name
-      "        expect(page).to have_content(#{assoc}1.#{HotGlue.derrive_reference_name(class_name)})"
-
-      elsif type == :boolean
-      '        expect(page).to have_content(new_' + col.to_s + ' ? "YES" : "NO")'
-
-      elsif type == :enum && eval("#{singular_class}.respond_to?(:#{col}_labels)")
-       "        expect(page).to have_content(#{singular_class}.#{col}_labels[new_#{col}])"
-      elsif type == :string && eval("#{singular_class}.respond_to?(:devise_modules)") &&
-           #devise confirmable makes email updates go into unconfirmed_email
-           eval("#{singular_class}.devise_modules.include?(:confirmable)") && col.to_s == "email"
-            "        expect(page).to have_content(#{ singular }1.#{col.to_s})"
-      elsif type == :datetime
-            "        expect(page).to have_content(new_#{col.to_s}.in_time_zone(testing_timezone).strftime('%m/%d/%Y @ %l:%M %p %z').gsub('  ', ' '))"
-      else
-            "        expect(page).to have_content(new_#{col.to_s})"
-      end
-    }.compact.join("\n")
-    %>
+<%= "        " + @columns_map.map{ |col, col_object|
+  if @attachments.keys.collect(&:to_sym).include?(col)
+  elsif @show_only.include?(col)
+  else
+      col_object.spec_make_assertion
+  end
+ }.compact.join("\n        ")
+  %>
       end
     end
   end <% end %>

--- a/spec/lib/hot_glue/controller_helper_spec.rb
+++ b/spec/lib/hot_glue/controller_helper_spec.rb
@@ -66,7 +66,7 @@ describe HotGlue::ControllerHelper do
     it "should render a time field output" do
       expect(fake_controller.time_field_localized(
         form_builder, :when_at, nil, "When at"
-      )).to eq("<input class=\"form-control\" type=\"time\" name=\"Xyz[when_at]\" id=\"Xyz_when_at\" />+00:00")
+      )).to eq("<input class=\"form-control\" type=\"time\" name=\"Xyz[when_at]\" id=\"Xyz_when_at\" />")
 
     end
   end

--- a/spec/lib/hot_glue/controller_helper_spec.rb
+++ b/spec/lib/hot_glue/controller_helper_spec.rb
@@ -87,14 +87,14 @@ describe HotGlue::ControllerHelper do
 
       describe "When the current user does not have a timezone" do
         it "should return the server timezone" do
-          expect(fake_controller.current_timezone).to eq( Time.now.strftime("%z").to_i/100)
+          expect(fake_controller.current_timezone).to eq("UTC")
         end
       end
     end
 
     describe "when current_user is not defined" do
       it "should return the server timezone" do
-        expect(fake_controller.current_timezone).to eq( Time.now.strftime("%z").to_i/100)
+        expect(fake_controller.current_timezone).to eq("UTC")
       end
     end
   end

--- a/spec/lib/hot_glue/markup_templates/erb_spec.rb
+++ b/spec/lib/hot_glue/markup_templates/erb_spec.rb
@@ -151,17 +151,17 @@ describe HotGlue::ErbTemplate do
 
     it "should make a datetime column" do
       res = factory_all_form_fields({columns: [:approved_at]})
-      expect(res).to include("<%= datetime_field_localized(f, :approved_at, jkl.approved_at, 'Approved at', nil) %>")
+      expect(res).to include("<%= datetime_field_localized(f, :approved_at, jkl.approved_at, 'Approved at') %>")
     end
 
     it "should make a date column " do
       res = factory_all_form_fields({columns: [:release_on]})
-      expect(res).to include("<%= date_field_localized(f, :release_on, jkl.release_on, 'Release on', nil) %>")
+      expect(res).to include("<%= date_field_localized(f, :release_on, jkl.release_on, 'Release on') %>")
     end
 
     it "should make a time column " do
       res = factory_all_form_fields({columns: [:time_of_day]})
-      expect(res).to include("<%= time_field_localized(f, :time_of_day, jkl.time_of_day,  'Time of day', nil) %>")
+      expect(res).to include("<%= time_field_localized(f, :time_of_day, jkl.time_of_day,  'Time of day') %>")
     end
 
     it "should make a boolean column " do


### PR DESCRIPTION
fixes variable names be more clear whethor or not they are TimeZone objects (https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html) or are UTC offset (integers -/+ from UTC)
see spec failures on HGDateTimeNoUser
2023-09-01- solved- this was caused by a nasty race condition due to using random dates for the DateTime and the Time assertions in the generated specs. note that the _input mechanism_ presumed to convert the datetime object as-if the user were entering the time _in their own timezone_.  Previously, this behavior was applied to DateTime, Date, and Time fields. now this behavior is applied only to DateTime fields

```

  1) interaction for AbcsController new & create should create a new Abc
     Failure/Error: expect(page).to have_content(new_when_at.in_time_zone(testing_timezone).strftime('%m/%d/%Y @ %l:%M %p %Z').gsub('  ', ' '))
       expected to find text "11/13/2023 @ 11:54 AM EST" in "Successfully created Christmas on Ferry Fall\nABCS\nNew Abc\n\nName\nWhen at\nThe time\nNuclear Thief\n08/31/2023 @ 12:58 PM EDT\n1:21 PM +00:00\nEdit\nChristmas on Ferry Fall\n11/13/2023 @ 12:54 PM EST\nMISSING\nEdit"
     # ./spec/features/abcs_behavior_spec.rb:44:in `block (3 levels) in <top (required)>'
     # /Users/jason/.rvm/gems/ruby-3.2.2/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <main>'

  2) interaction for AbcsController edit & update should return an editable form
     Failure/Error: expect(page).to have_content(new_when_at.in_time_zone(testing_timezone).strftime('%m/%d/%Y @ %l:%M %p %z').gsub('  ', ' '))
       expected to find text "10/28/2023 @ 12:54 PM -0400" in "The Dreams Without a Witch\n10/28/2023 @ 12:54 PM EDT\nMISSING\nEdit"
     # ./spec/features/abcs_behavior_spec.rb:65:in `block (4 levels) in <top (required)>'
     # /Users/jason/.rvm/gems/ruby-3.2.2/gems/capybara-3.39.2/lib/capybara/session.rb:365:in `within'
     # /Users/jason/.rvm/gems/ruby-3.2.2/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `call'
     # /Users/jason/.rvm/gems/ruby-3.2.2/gems/capybara-3.39.2/lib/capybara/dsl.rb:52:in `within_element'
     # /Users/jason/.rvm/gems/ruby-3.2.2/gems/capybara-3.39.2/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
     # ./spec/features/abcs_behavior_spec.rb:63:in `block (3 levels) in <top (required)>'
     # /Users/jason/.rvm/gems/ruby-3.2.2/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <main>'

Finished in 6.01 seconds (files took 0.86691 seconds to load)
6 examples, 2 failures, 1 pending

Failed examples:

rspec ./spec/features/abcs_behavior_spec.rb:28 # interaction for AbcsController new & create should create a new Abc
rspec ./spec/features/abcs_behavior_spec.rb:51 # interaction for AbcsController edit & update should return an editable form
```


- [ ] then test it against having a current_user in scope (`@auth_identifier` set), should check for user's timezone 