### PR TITLE
adds pundit authorize to the load_ action

### DIFF
--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -1,6 +1,8 @@
 class <%= controller_class_name %> < <%= controller_descends_from %>
   # regenerate this controller with
-  # <%= regenerate_me_code %>
+  <% if defined?(RuboCop) %># rubocop:disable Layout/LineLength
+  <% end %># <%= regenerate_me_code %><% if defined?(RuboCop) %>
+  # rubocop:enable Layout/LineLength <% end %>
 
   helper :hot_glue
   include HotGlue::ControllerHelper
@@ -59,6 +61,7 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
       @<%= singular_name %> = <%= object_scope.gsub("@",'') %>.find(params[:id])
     else <% end %>@<%= singular_name %> = <%= object_scope %>.find(params[:id])<% if @nested_set[0] && @nested_set[0][:optional]  %>
     end<% end %>
+    <% if @pundit %>authorize @<%= singular_name %><% end %>
   end
   <% else %>
   def load_<%= singular_name %>

--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -61,8 +61,8 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
       @<%= singular_name %> = <%= object_scope.gsub("@",'') %>.find(params[:id])
     else <% end %>@<%= singular_name %> = <%= object_scope %>.find(params[:id])<% if @nested_set[0] && @nested_set[0][:optional]  %>
     end<% end %>
-    <% if @pundit %>authorize @<%= singular_name %><% end %>
-  end
+<% if @pundit %>    authorize @<%= singular_name %>
+<% end %>  end
   <% else %>
   def load_<%= singular_name %>
     @<%= singular_name %> = (<%= auth_object.gsub("@",'') %><%= " if params.include?(:#{@nested_set[0][:singular]}_id)" if @nested_set.any? && @nested_set[0][:optional] %>)<% if @nested_set.any? && @nested_set[0][:optional] %> || <%= class_name %>.find(params[:id])<% end %>


### PR DESCRIPTION
• adds pundit authorization to the load_* actions (edit) #117

this allows you to use `  after_action :verify_authorized` globally in your ApplicationController

• adds RuboCop detection: if you have Rubocop, the regeneration code at the top of the controller is excluded from the line length cop using
```
# rubocop:disable Layout/LineLength
...
# rubocop:enable Layout/LineLength
```