### PR TITLE
fixes problem with save code in sysem spec code if you ran the code t…

### DIFF
--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -715,19 +715,19 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
       if File.exist?(dest_file)
         existing_file = File.open(dest_file)
         existing_content = existing_file.read
-        if existing_content =~ /\#HOTGLUE-SAVESTART/
-          if existing_content !~ /\#HOTGLUE-END/
-            raise "Your file at #{dest_file} contains a #HOTGLUE-SAVESTART marker without #HOTGLUE-END"
+        if existing_content =~ /\# HOTGLUE-SAVESTART/
+          if existing_content !~ /\# HOTGLUE-END/
+            raise "Your file at #{dest_file} contains a # HOTGLUE-SAVESTART marker without # HOTGLUE-END"
           end
-          @existing_content = existing_content[(existing_content =~ /\#HOTGLUE-SAVESTART/)..(existing_content =~ /\#HOTGLUE-END/) - 1]
-          @existing_content << "#HOTGLUE-END"
+          @existing_content = existing_content[(existing_content =~ /\# HOTGLUE-SAVESTART/)..(existing_content =~ /\# HOTGLUE-END/) - 1]
+          @existing_content << "# HOTGLUE-END"
 
         else
-          @existing_content = "  #HOTGLUE-SAVESTART\n  #HOTGLUE-END"
+          @existing_content = "  # HOTGLUE-SAVESTART\n  # HOTGLUE-END"
         end
         existing_file.rewind
       else
-        @existing_content = "  #HOTGLUE-SAVESTART\n  #HOTGLUE-END"
+        @existing_content = "  # HOTGLUE-SAVESTART\n  # HOTGLUE-END"
       end
 
       template "system_spec.rb.erb", dest_file


### PR DESCRIPTION
…hrough rubocop lint. Since lint change '#HOTGLUE-SAVESTART' to '# HOTGLUE-SAVESTART', regenerating after linting would wipe away the saved code. after this change, be sure that all your save code begins with # HOTGLUE-SAVESTART and ends with # HOTGLUE-END (notice the space after the # symbol). if it doesn't, add it before regenerating to prevent loss of save code; if you use rubocop lint and have already linted your code, you can ignore as newly generate code will work with the linted code