### PR TITLE
refactors contextual timezone; your current_user object should now ha…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hot-glue (0.6.4)
+    hot-glue (0.6.5)
       ffaker (~> 2.16)
       kaminari (~> 1.2)
       rails (> 5.1)

--- a/lib/generators/hot_glue/fields/date_time_field.rb
+++ b/lib/generators/hot_glue/fields/date_time_field.rb
@@ -3,6 +3,12 @@ class DateTimeField < Field
     Time.now + rand(1..5).days
   end
 
+
+  def form_show_only_output
+    viewable_output
+  end
+
+
   def spec_setup_and_change_act(which_partial = nil)
     "      " + "new_#{name} = DateTime.current + 1.year \n" +
     '      ' + "find(\"[name='#{testing_name}[#{ name.to_s }]']\").fill_in(with: new_#{name.to_s})"
@@ -48,6 +54,9 @@ class DateTimeField < Field
   <% end %>"
     end
   end
+
+
+
 
   def search_field_output
     if !modify_binary?

--- a/lib/generators/hot_glue/fields/field.rb
+++ b/lib/generators/hot_glue/fields/field.rb
@@ -131,6 +131,7 @@ class Field
 
   def modified_display_output
     res = +''
+
     if modify_as[:cast] && modify_as[:cast] == "$"
       res += "<%= number_to_currency(#{singular}.#{name}) %>"
     elsif modify_as[:binary]
@@ -151,7 +152,9 @@ class Field
                    end
       res = "<span class='badge <%= #{badge_code} %>'>" + res + "</span>"
     end
+    # byebug
 
+    res
   end
 
   def field_output(type = nil, width )

--- a/lib/generators/hot_glue/markup_templates/erb.rb
+++ b/lib/generators/hot_glue/markup_templates/erb.rb
@@ -158,7 +158,6 @@ module  HotGlue
             end
 
             @tinymce_stimulus_controller = (columns_map[col].modify_as == {tinymce: 1} ?  "data-controller='tiny-mce' " : "")
-
             add_spaces_each_line( "\n  <span #{@tinymce_stimulus_controller}class='<%= \"alert alert-danger\" if #{singular}.errors.details.keys.include?(:#{field_error_name}) %>'  #{'style="display: inherit;"'}  >\n" +
                                     add_spaces_each_line( (form_labels_position == 'before' ? the_label || "" : "") +
                                                         +  " <br />\n" + field_result +

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -756,7 +756,6 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
       @columns = @the_object.columns.map(&:name).map(&:to_sym).reject { |field| !@include_fields.include?(field) }
     end
 
-
     @columns = @columns -@nested_set.collect { |set| (set[:singular] + "_id").to_sym  }
 
     if @attachments.any?


### PR DESCRIPTION
…ve (1) a field on the database  (notice underscore) this is a string field storing the name of the Rails timezone, (2) a  method like def timezone; ActiveSupport::TimeZone[time_zone]; end  .. notice the method does not have an underscore and returns a TimeZone object