### PR TITLE
pundit policy override

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hot-glue (0.6.14)
+    hot-glue (0.6.15)
       ffaker (~> 2.16)
       kaminari (~> 1.2)
       rails (> 5.1)

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -91,6 +91,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
   class_option :modify, default: {}
   class_option :display_as, default: {}
   class_option :pundit, default: nil
+  class_option :pundit_policy_override, default: nil
   class_option :related_sets, default: ''
   class_option :code_before_create, default: nil
   class_option :code_after_create, default: nil
@@ -357,6 +358,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
 
 
     @pundit = options['pundit']
+    @pundit_policy_override = options['pundit_policy_override']
 
     @no_nav_menu = options['no_nav_menu']
 

--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -78,11 +78,12 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
   end
 
   def index
-    load_all_<%= plural %>
-      <% if @search_fields %>
+    load_all_<%= plural %><% if @search_fields %>
 <%= @search_fields.collect{|field_name| @columns_map[field_name.to_sym].code_to_reset_match_if_search_is_blank}.compact.join("     \n") %><% end %>
-    load_all_<%= plural %><% if @pundit %><% if @pundit %>
-    authorize @<%= plural_name %><% end %>
+    <% if @pundit %><% if @pundit && !@pundit_policy_override %>
+    authorize @<%= plural_name %><% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.index?<% end %>
   rescue Pundit::NotAuthorizedError
     flash[:alert] = 'You are not authorized to perform this action.'
     render 'layouts/error'<% end %>
@@ -92,7 +93,10 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
     @<%= singular_name %> = <%= class_name %>.new<% if eval("#{class_name}.reflect_on_association(:#{@object_owner_sym})").class == ActiveRecord::Reflection::BelongsToReflection  %>(<%= @object_owner_sym %>: <%= @object_owner_eval %>)<% end %><% elsif @object_owner_optional && any_nested? %>
     @<%= singular_name %> = <%= class_name  %>.new({}.merge(<%= @nested_set.last[:singular] %> ? {<%= @object_owner_sym %>: <%= @object_owner_eval %>} : {}))<% else %>
     @<%= singular_name %> = <%= class_name  %>.new(<% if any_nested? %><%= @object_owner_sym %>: <%= @object_owner_eval %><% end %>)<% end %>
-    <% if @pundit %>authorize @<%= singular_name %><% end %><% if @pundit %>
+    <% if @pundit && !@pundit_policy_override %>
+    authorize @<%= singular %><% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.new?<% end %><% if @pundit %>
     @action = 'new'
   rescue Pundit::NotAuthorizedError
     flash[:alert] = 'You are not authorized to perform this action.'
@@ -112,7 +116,10 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
     <%= creation_syntax %>
     <% if @pundit %><% @related_sets.each do |key, related_set| %>
     check_<%= related_set[:association_ids_method].to_s %>_permissions(modified_params, :create)<% end %><% end %>
-    <% if @pundit %>authorize @<%= singular %><% end %>
+      <% if @pundit && !@pundit_policy_override %>
+    authorize @<%= singular %><% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.create?<% end %>
     <%= @code_before_create ? "\n    " + @code_before_create.gsub(";", "\n") : "" %>
     if @<%= singular_name %>.save<%= @code_after_create ? ("\n      " + @code_after_create.gsub(";", "\n"))  : ""%>
       flash[:notice] = "Successfully created #{@<%= singular %>.<%= display_class %>}"
@@ -148,8 +155,10 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
 
 <% end %>
 <% unless @no_edit %>
-  def show<% if @pundit %>
-    authorize @<%= singular %><% end %>
+  def show<% if @pundit && !@pundit_policy_override %>
+    authorize @<%= singular %><% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.show?<% end %>
     redirect_to <%=  HotGlue.optionalized_ternary(namespace: @namespace,
                                  target:  @singular,
                                  top_level: false,
@@ -160,8 +169,10 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
                                  put_form: true).gsub("(#{singular}", "(@#{singular}") %>
   end
 
-  def edit<% if @pundit  %>
-    authorize @<%= singular_name %><% end %>
+  def edit<% if @pundit && !@pundit_policy_override %>
+    authorize @<%= singular %><% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.edit?<% end %>
     @action = 'edit'
     render :edit<% if @pundit %>
   rescue Pundit::NotAuthorizedError
@@ -187,15 +198,19 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
 
     <% if @hawk_keys.any? %>    modified_params = hawk_params({<%= hawk_to_ruby %>}, modified_params)<% end %>
     <%= controller_attachment_orig_filename_pickup_syntax %>
-    <% if @pundit %>
-    if @<%= singular_name %>.attributes = modified_params
+      <% if @pundit && !@pundit_policy_override %>
       authorize @<%= singular_name %>
       <%= @code_before_update ? "\n    " + @code_before_update.gsub(";", "\n") : "" %>
-      @<%= singular_name %>.save
-      <% else %>
-    <%= @code_before_update ? "\n    " + @code_before_update.gsub(";", "\n") : "" %>
+
     if @<%= singular_name %>.update(modified_params)
-    <% end %>
+
+    <% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.update?
+    if @<%= singular_name %>.update(modified_params)
+      <% else %>
+      <%= @code_before_update ? "\n    " + @code_before_update.gsub(";", "\n") : "" %>
+    if @<%= singular_name %>.update(modified_params)<% end %>
       <%= post_action_parental_updates.compact.join("\n      ") %>
       <%= @code_after_update ? "\n    " + @code_after_update.gsub(";", "\n") : "" %>
       <% if @display_list_after_update %>    load_all_<%= plural %><% end %>
@@ -216,11 +231,14 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
   end
 
 <% end %><% if destroy_action %>  def destroy
-    <% if @pundit %>authorize @<%= singular_name %><% end %>
+    <% if @pundit && !@pundit_policy_override %>
+    authorize @<%= singular %><% elsif @pundit && @pundit_policy_override %>
+    skip_authorization
+    raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.destroy?<% end %>
     begin
       @<%=singular_name%>.destroy
       flash[:notice] = '<%= singular_name.titlecase %> successfully deleted'
-    rescue StandardError => e
+    rescue ActiveRecordError => e
       flash[:alert] = '<%= singular_name.titlecase %> could not be deleted'
     end
     <%= post_action_parental_updates.join("\n    ") %>

--- a/lib/generators/hot_glue/templates/erb/edit.erb
+++ b/lib/generators/hot_glue/templates/erb/edit.erb
@@ -8,30 +8,40 @@
 <% if @big_edit %>
     </div>
   </div>
+</div>
+
 
 
 <% if @downnest_children.any? && @big_edit %>
-  <hr />
-  <% each_downnest_width = @downnest_children.count == 1 ? 33 : (53/@downnest_children.count).floor %>
-    <% @downnest_object.each do |downnest, size| %>
-      <div class="row">
-        <div class="col-md-<%= @big_edit  ? 12 : 6  %>">
+<div class="container" data-controller="bootstrap-tabbed-nav">
+    <ul class="nav nav-tabs" id="<%= singular + "_downnest_portals" %>" role="tablist">
+      <% @downnest_object.each_with_index do |data,index| %>
+        <% downnest = data[0] %>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link <%= "active" if index==0 %>" id="<%= downnest %>-tab" data-bs-toggle="tab" data-bs-target="#<%= downnest %>-portal" type="button" role="tab" aria-controls="home" aria-selected="true">
+            <%= downnest.upcase %>
+          </button>
+        </li>
+      <% end %>
+    </ul>
+
+    <div class="tab-content" id="myTabContent">
+      <% @downnest_object.each_with_index do |data, index| %>
+        <% downnest = data[0] %>
+        <div class="tab-pane fade <%= "show active" if index==0 %>" id="<%= downnest %>-portal" role="tabpanel" aria-labelledby="<%= downnest %>-tab">
           <% downnest_object =  eval("#{singular_class}.reflect_on_association(:#{downnest})") %>
           <% if downnest_object.nil?; raise "no relationship for downnested portal `#{downnest}` found on `#{singular_class}`; please check relationship for has_many :#{downnest}"; end; %>
           <% downnest_class = downnest_object.class_name %>
           <% downnest_object_name = eval("#{downnest_class}.table_name") %>
           <% downnest_style = @layout_strategy.downnest_style %>
-          <% if @downnest_shows_headings %>
-            <h3>
-              <%= downnest_class.titlecase.pluralize %>
-            </h3>
-          <% end %>
-          <\%= render partial: "<%= namespace_with_trailing_dash %><%= downnest_object_name %>/list", locals: {<%= @singular %>: @<%= @singular %>,  <%= downnest_object_name %>: @<%= @singular %>.<%= downnest %><% if @nested_set.any? %>, <%= @nested_set.collect{|x| "#{x[:singular]}: @#{x[:singular]}"}.join(", ") %>, nested_for: "<%= @nested_set.collect{|x| "#{x[:singular]}-" + "\#{" + "@#{x[:singular]}.id}"}.join("__") %>__<%= singular %>-#{@<%= @singular %>.id}" <% end %> } \%>
 
-          </div>
+          <\%= render partial: "<%= namespace_with_trailing_dash %><%= downnest_object_name %>/list", locals: {<%= @singular %>: @<%= @singular %>,  <%= downnest_object_name %>: @<%= @singular %>.<%= downnest %><% if @nested_set.any? %>, <%= @nested_set.collect{|x| "#{x[:singular]}: @#{x[:singular]}"}.join(", ") %>, nested_for: "<%= @nested_set.collect{|x| "#{x[:singular]}-" + "\#{" + "@#{x[:singular]}.id}"}.join("__") %>__<%= singular %>-#{@<%= @singular %>.id}" <% end %> } \%>
         </div>
       <% end %>
-  <% end %>
+    </div>
+
 </div>
 <% end %>
 
+
+<% end %>


### PR DESCRIPTION
if you use the flag `--pundit-policy-override` your controller operations will bypass the invisible (pundit provided) access control and use the pundit policy you specify.

example

`rails generate hot_glue:scaffold Invoice --gd --pundit-policy-override='UniqueInvoicePolicy'`

You will implement a Pundit policy for `UniqueInvoicePolicy` and it should implement actions with question mark `?` endings corresponding to the same actions you are building, `new?`, `create?`, `edit?`, `update?`, and `destroy?`

If provided, the output code looks something like (in this example, showing the `edit?` method)

```
    skip_authorization
    raise Pundit::NotAuthorizedError if ! UniqueInvoicePolicy.edit?
```

