### PR TITLE
Jfb/2025 01 30

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hot-glue (0.6.10)
+    hot-glue (0.6.11)
       ffaker (~> 2.16)
       kaminari (~> 1.2)
       rails (> 5.1)
@@ -76,6 +76,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
     bcrypt (3.1.18)
     builder (3.2.4)
     byebug (11.1.3)
@@ -139,7 +140,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.4)
     minitest (5.16.3)
-    net-imap (0.5.4)
+    net-imap (0.5.5)
       date
       net-protocol
     net-pop (0.1.2)
@@ -245,7 +246,8 @@ GEM
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket (1.2.9)
-    websocket-driver (0.7.6)
+    websocket-driver (0.7.7)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)

--- a/lib/generators/hot_glue/fields/association_field.rb
+++ b/lib/generators/hot_glue/fields/association_field.rb
@@ -111,8 +111,8 @@ class AssociationField < Field
       # end
     elsif modify_as && modify_as[:typeahead]
       search_url  = "#{namespace ? namespace + "_" : ""}" +
-        modify_as[:nested].join("_") +
-        + "_#{assoc.class_name.downcase.pluralize}_typeahead_index_url"
+        modify_as[:nested].join("_") + ("_" if modify_as[:nested].any?) +
+        + "#{assoc.class_name.downcase.pluralize}_typeahead_index_url"
 
 
       if @modify_as[:nested].any?

--- a/lib/generators/hot_glue/fields/boolean_field.rb
+++ b/lib/generators/hot_glue/fields/boolean_field.rb
@@ -40,19 +40,18 @@ class BooleanField < Field
     if display_boolean_as.nil?
 
     end
-    "<div class='#{@layout_strategy.form_checkbox_wrapper_class} #{'form-switch' if display_boolean_as == 'switch'}'>\n" +
+    "<span class='#{@layout_strategy.form_checkbox_wrapper_class} #{'form-switch' if display_boolean_as == 'switch'}'>\n" +
       (if display_boolean_as == 'radio'
       radio_button_display
     elsif display_boolean_as == 'checkbox'
       checkbox_display
     elsif display_boolean_as == 'switch'
       switch_display
-   end) + "</div> \n"
+   end) + "</span> \n"
   end
 
   def form_field_output
-    (form_labels_position == 'before' ?  " <br />"  : "") +
-      form_field_display + (form_labels_position == 'after' ?  " <br />"  : "")
+    form_field_display
   end
 
   def line_field_output

--- a/lib/generators/hot_glue/fields/date_time_field.rb
+++ b/lib/generators/hot_glue/fields/date_time_field.rb
@@ -40,7 +40,7 @@ class DateTimeField < Field
   end
 
   def form_field_output
-    "<%= f.datetime_field( :#{name}, value: #{singular}.#{name} && #{singular}.#{name}.change(sec: 0), class: '#{@layout_strategy.form_input_class}'  ) %>"
+    "<%= f.datetime_field( :#{name}, value: #{singular}.#{name} && #{singular}.#{name}.in_time_zone(current_timezone), class: '#{@layout_strategy.form_input_class}'  ) %><%= current_timezone %>"
   end
 
   def viewable_output

--- a/lib/generators/hot_glue/fields/related_set_field.rb
+++ b/lib/generators/hot_glue/fields/related_set_field.rb
@@ -3,7 +3,7 @@ class RelatedSetField < Field
   attr_accessor :assoc_name, :assoc_class, :assoc
 
   def initialize( class_name: , default_boolean_display:, display_as: ,
-                  name: , singular: ,
+                  name: , singular: , plural:,
                   alt_lookup: ,
                   update_show_only: ,
                   hawk_keys: , auth: , sample_file_path:,  ownership_field: ,

--- a/lib/generators/hot_glue/markup_templates/erb.rb
+++ b/lib/generators/hot_glue/markup_templates/erb.rb
@@ -156,18 +156,20 @@ module  HotGlue
                 "<% if @action == 'new' && policy(@#{singular}).#{col}_able? %>" + columns_map[col].form_field_output + "<% else %>" + columns_map[col].form_show_only_output + "<% end %>"
 
                  # show only on the update action overrides any pundit policy
-            elsif @pundit && eval("defined? #{singular_class}Policy") && eval("#{singular_class}Policy").instance_methods.include?("#{col}_able?".to_sym)
-              "<% if policy(@#{singular}).#{col}_able? %>" + columns_map[col].form_field_output + "<% else %>" + columns_map[col].form_show_only_output  + "<% end %>"
-            else
-              columns_map[col].form_field_output
-            end
+              elsif @pundit && eval("defined? #{singular_class}Policy") && eval("#{singular_class}Policy").instance_methods.include?("#{col}_able?".to_sym)
+                "<% if policy(@#{singular}).#{col}_able? %>" + columns_map[col].form_field_output + "<% else %>" + columns_map[col].form_show_only_output  + "<% end %>"
+              else
+                columns_map[col].form_field_output
+              end
+
 
             @tinymce_stimulus_controller = (columns_map[col].modify_as == {tinymce: 1} ?  "data-controller='tiny-mce' " : "")
+
             add_spaces_each_line( "\n  <span #{@tinymce_stimulus_controller}class='<%= \"alert alert-danger\" if #{singular}.errors.details.keys.include?(:#{field_error_name}) %>'  #{'style="display: inherit;"'}  >\n" +
-                                    add_spaces_each_line( (form_labels_position == 'before' ? the_label || "" : "") +
-                                                        +  " <br />\n" + field_result +
-                                        (form_labels_position == 'after' ? the_label : "")   , 4) +
-                                    "\n  </span>\n  <br />", 2)
+                                    add_spaces_each_line( (form_labels_position == 'before' ? (the_label || "") + "<br />\n"  : "") +
+                                                        +  field_result +
+                                        (form_labels_position == 'after' ? "<br />\n" + (the_label || "") : "")  , 4) +
+                                    "\n  </span>\n ", 2)
 
           }.join("") + "\n  </div>"
       }.join("\n")

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -81,7 +81,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
   class_option :form_placeholder_labels, type: :boolean, default: false # puts the field names into the placeholder labels
 
   # determines if labels appear within the rows of the VIEWABLE list (does NOT affect the list heading)
-  class_option :inline_list_labels, default: 'omit' # choices are before, after, omit
+  class_option :inline_list_labels, default: nil # default is set below
   class_option :factory_creation, default: ''
   class_option :alt_foreign_key_lookup, default: '' #
   class_option :attachments, default: ''
@@ -262,7 +262,11 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
         elsif $2 == "tinymce"
           @modify_as[key.to_sym] =  {tinymce: 1, badges: $3}
         elsif $2 == "typeahead"
-          nested = $3.split("/")
+          if !$3.nil?
+            nested = $3.split("/")
+          else
+            nested = []
+          end
           @modify_as[key.to_sym] =  {typeahead: 1, nested: nested}
         elsif $2 == "timezone"
           @modify_as[key.to_sym] =  {timezone: 1, badges: $3}
@@ -303,7 +307,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
 
     setup_hawk_keys
     @form_placeholder_labels = options['form_placeholder_labels'] # true or false
-    @inline_list_labels = options['inline_list_labels'] || 'omit' # 'before','after','omit'
+    @inline_list_labels = options['inline_list_labels'] || get_default_from_config(key: :inline_list_labels) || 'omit' # 'before','after','omit'
 
     @form_labels_position = options['form_labels_position']
     if !['before', 'after', 'omit'].include?(@form_labels_position)

--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -72,13 +72,14 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
     params[:per] || 10
   end<% end %>
   <% unless @no_list %>
-  def load_all_<%= plural %>
+  def load_all_<%= plural %><% if @search == "set" %>
+    @q = params[:q] ||  <%= {"0" => @search_fields.collect{|foo| {"#{foo}_match".to_sym => ((@columns_map[foo.to_sym].modify_as && @columns_map[foo.to_sym].modify_as[:binary]) ? "-1" : ""), "#{foo}_search".to_sym => ""}}.reduce({}, :merge)  } %> <% end %>
   <%= load_all_code %>
   end
 
-  def index<% if @search == "set" %>
-    @q = params[:q] ||  <%= {"0" => @search_fields.collect{|foo|
-    {"#{foo}_match".to_sym => ((@columns_map[foo.to_sym].modify_as && @columns_map[foo.to_sym].modify_as[:binary]) ? "-1" : ""), "#{foo}_search".to_sym => ""}}.reduce({}, :merge)  } %> <% end %><% if @search_fields %>
+  def index
+    load_all_<%= plural %>
+      <% if @search_fields %>
 <%= @search_fields.collect{|field_name| @columns_map[field_name.to_sym].code_to_reset_match_if_search_is_blank}.compact.join("     \n") %><% end %>
     load_all_<%= plural %><% if @pundit %><% if @pundit %>
     authorize @<%= plural_name %><% end %>

--- a/spec/lib/hot_glue/markup_templates/erb_spec.rb
+++ b/spec/lib/hot_glue/markup_templates/erb_spec.rb
@@ -182,7 +182,7 @@ describe HotGlue::ErbTemplate do
 
     it "should make a datetime column" do
       res = factory_all_form_fields({columns: [:approved_at]})
-      expect(res).to include("<%= f.datetime_field( :approved_at, value: jkl.approved_at && jkl.approved_at.change(sec: 0), class: ''  ) %>")
+      expect(res).to include("<%= f.datetime_field( :approved_at, value: jkl.approved_at && jkl.approved_at.in_time_zone(current_timezone), class: ''  ) %>")
     end
 
     it "should make a date column " do


### PR DESCRIPTION
• inline_list_labels can be set in hot_glue.yml
• typeaheads nested inside of routes are fixed 
• switches back to `current_timezone` implementation, displaying times relative to the user's set timezone
• load all code now sets query parameters
