### PR TITLE
--code-after-new and more

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hot-glue (0.6.19)
+    hot-glue (0.6.20)
       ffaker (~> 2.16)
       kaminari (~> 1.2)
       rails (> 5.1)

--- a/README.md
+++ b/README.md
@@ -1361,17 +1361,31 @@ Use `before` to make the labels come before or `after` to make them come after. 
 
 
 ### Code insertions
+Insert some code into the `new`, `create` or `update` action actions.
 
-### `--code-before-create=`
-### `--code-after-create=`
-### `--code-before-update=`
-### `--code-after-update=`
-
-Insert some code into the `create` action or `update` actions.
-The **before code** is called _after authorization_ but _before saving_ (which creates the record, or fails validation).
-The **after create** code is called after the record is saved (and thus has an id in the case of the create action).
-Both should be wrapped in quotation marks when specified in the command line, and use semicolons to separate multiple lines of code.
+Wrapped in quotation marks when specified in the command line, and use semicolons to separate multiple lines of code.
 (Notice the funky indentation of the lines in the generated code. Adjust you input to get the indentation correct.)
+
+
+
+#### `--code-before-create=`
+
+called _after authorization_ but _before saving the new record_ 
+(which creates the record, or fails validation).
+Here you can do things like set default values, or modify the params before the record is saved.
+
+#### `--code-after-create=`
+is called after the record is saved (and thus has an id in the case of the create action).
+
+#### `--code-before-update=`
+is called in the `update` action _before_ it is saved.
+`
+#### `--code-after-update=`
+is called in the `update` action _after_ it is saved.
+
+#### `--code-after-new=`
+is called in the `new` after the .new() call
+
 
 
 

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -106,6 +106,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
   class_option :code_after_create, default: nil
   class_option :code_before_update, default: nil
   class_option :code_after_update, default: nil
+  class_option :code_after_new, default: nil
   class_option :record_scope, default: nil
   class_option :no_nav_menu, type: :boolean, default: false # suppress writing to _nav template
   class_option :include_object_names, type: :boolean, default: false
@@ -531,6 +532,7 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
     @code_after_create = options['code_after_create']
     @code_before_update = options['code_before_update']
     @code_after_update = options['code_after_update']
+    @code_after_new = options['code_after_new']
 
     buttons_width = ((!@no_edit && 1) || 0) + ((!@no_delete && 1) || 0) + @magic_buttons.count
 
@@ -967,10 +969,8 @@ class HotGlue::ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
       #{@factory_creation}
       "
       res << "\n      " + "@#{singular} = factory.#{singular}" unless res.include?("@#{singular} = factory.#{singular}")
-      res << "\n      flash[:notice] = \"Successfully created \#{@#{singular}.name}\" unless @#{singular}.new_record?
-    rescue ActiveRecord::RecordInvalid
+      res << "\n    rescue ActiveRecord::RecordInvalid
       @#{singular} = factory.#{singular}
-      flash[:alert] = \"Oops, your #{singular} could not be created. #{@hawk_alarm}\"
       @action = 'new'
     end"
       res

--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -95,6 +95,8 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
     @<%= singular_name %> = <%= class_name %>.new<% if eval("#{class_name}.reflect_on_association(:#{@object_owner_sym})").class == ActiveRecord::Reflection::BelongsToReflection  %>(<%= @object_owner_sym %>: <%= @object_owner_eval %>)<% end %><% elsif @object_owner_optional && any_nested? %>
     @<%= singular_name %> = <%= class_name  %>.new({}.merge(<%= @nested_set.last[:singular] %> ? {<%= @object_owner_sym %>: <%= @object_owner_eval %>} : {}))<% else %>
     @<%= singular_name %> = <%= class_name  %>.new(<% if any_nested? %><%= @object_owner_sym %>: <%= @object_owner_eval %><% end %>)<% end %>
+    <%=  @code_after_new ?  @code_after_new.gsub(";","\n") + "\n" : "" %>
+
     <% if @pundit && !@pundit_policy_override %>
     authorize @<%= singular %><% elsif @pundit && @pundit_policy_override %>
     skip_authorization
@@ -216,19 +218,20 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
     <% end %>
    <% if @hawk_keys.any? %> modified_params = hawk_params({<%= hawk_to_ruby %>}, modified_params)<% end %>
     <%= controller_attachment_orig_filename_pickup_syntax %>
+      @<%= singular_name %>.assign_attributes(modified_params)
       <% if @pundit && !@pundit_policy_override %>
       authorize @<%= singular_name %>
       <%= @code_before_update ? "\n    " + @code_before_update.gsub(";", "\n") : "" %>
 
-    if @<%= singular_name %>.update(modified_params)
+    if @<%= singular_name %>.save
 
     <% elsif @pundit && @pundit_policy_override %>
     skip_authorization
     raise Pundit::NotAuthorizedError if ! <%= @pundit_policy_override %>.update?
-    if @<%= singular_name %>.update(modified_params)
+    if @<%= singular_name %>.save
       <% else %>
       <%= @code_before_update ? "\n    " + @code_before_update.gsub(";", "\n") : "" %>
-    if @<%= singular_name %>.update(modified_params)<% end %>
+    if @<%= singular_name %>.save<% end %>
       <%= post_action_parental_updates.compact.join("\n      ") %>
       <%= @code_after_update ? "\n    " + @code_after_update.gsub(";", "\n") : "" %>
       <% if @display_list_after_update %>    load_all_<%= plural %><% end %>

--- a/lib/generators/hot_glue/templates/controller.rb.erb
+++ b/lib/generators/hot_glue/templates/controller.rb.erb
@@ -218,7 +218,7 @@ class <%= controller_class_name %> < <%= controller_descends_from %>
     <% end %>
    <% if @hawk_keys.any? %> modified_params = hawk_params({<%= hawk_to_ruby %>}, modified_params)<% end %>
     <%= controller_attachment_orig_filename_pickup_syntax %>
-      @<%= singular_name %>.assign_attributes(modified_params)
+    @<%= singular_name %>.assign_attributes(modified_params)
       <% if @pundit && !@pundit_policy_override %>
       authorize @<%= singular_name %>
       <%= @code_before_update ? "\n    " + @code_before_update.gsub(";", "\n") : "" %>


### PR DESCRIPTION
Now use new code insertion `--code-after-new` for code that happens direclty after .new() call. use semicolon (;) to create linebreaks; no reason why the factories should insert flash messages

- removes duplicitous flash messages in factory context


- adds documentation for --code-before-create, --code-after-create, --code-before-update, --code-after-update (these features were already implmented)


- updates are now built using `.assign_attribtes` followed by `.save` (previously, they were updated with one `.update()` call); this allows your Pundit policy to check if the changed values are valid and raise if not allowed based on the changed data (can be checked on Rails models with `.changed`)



------

- [x] • in new still need to tap this away
`  modified_params = modified_params.dup.tap{ |ary| ary.delete('__add_self_to_room') }`

- [x] after new needed for
```
if @account.current_enrollment&.subscription&.includes_screensharing
    @room.enable_display_media = true
    end
```


- [x]  I see no reason why the factories should insert flash messages
- [ ] Magic buttons have names -- activate now should be 'started room' and 'start now'
- [x] in update we need  @room.assign_attributes(modified_params)
 to happen BEFORE @room.save
 
